### PR TITLE
feat: add Docker Compose development stack (#24)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# PostgreSQL Configuration
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+POSTGRES_DB=polymarket_tracker
+POSTGRES_USER=tracker
+POSTGRES_PASSWORD=dev_password
+
+# Constructed database URL (for application use)
+DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+
+# Redis Configuration
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_URL=redis://${REDIS_HOST}:${REDIS_PORT}
+
+# Optional: Development tool ports
+ADMINER_PORT=8080
+REDIS_INSIGHT_PORT=5540
+
+# Polygon RPC Configuration
+POLYGON_RPC_URL=https://polygon-rpc.com
+POLYGON_FALLBACK_RPC_URL=https://polygon-bor.publicnode.com
+
+# Polymarket API Configuration
+POLYMARKET_WS_URL=wss://ws-subscriptions-clob.polymarket.com/ws/market
+
+# Alert Webhooks (optional)
+DISCORD_WEBHOOK_URL=
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=

--- a/README.md
+++ b/README.md
@@ -120,13 +120,47 @@ cp .env.example .env
 # Edit .env with your API keys
 
 # Start infrastructure (PostgreSQL, Redis)
-docker-compose up -d
+docker compose up -d
+
+# Wait for services to be healthy
+docker compose ps
 
 # Install Python dependencies
 pip install -e .
 
+# Run database migrations
+alembic upgrade head
+
 # Run the tracker
 python -m src.main
+```
+
+### Docker Services
+
+The development stack includes:
+
+| Service | Port | Description |
+|---------|------|-------------|
+| PostgreSQL 15 | 5432 | Primary database |
+| Redis 7 | 6379 | Caching and pub/sub |
+| Adminer | 8080 | Database admin UI (optional) |
+| RedisInsight | 5540 | Redis admin UI (optional) |
+
+```bash
+# Start core services only
+docker compose up -d
+
+# Start with development tools (Adminer, RedisInsight)
+docker compose --profile tools up -d
+
+# View logs
+docker compose logs -f
+
+# Stop all services
+docker compose down
+
+# Stop and remove volumes (reset data)
+docker compose down -v
 ```
 
 ### Configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,72 @@
+version: "3.8"
+
+services:
+  postgres:
+    image: postgres:15
+    container_name: polymarket-postgres
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-polymarket_tracker}
+      POSTGRES_USER: ${POSTGRES_USER:-tracker}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-dev_password}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tracker} -d ${POSTGRES_DB:-polymarket_tracker}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+
+  redis:
+    image: redis:7
+    container_name: polymarket-redis
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis_data:/data
+    command: redis-server --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    restart: unless-stopped
+
+  # Optional development tools - use with: docker compose --profile tools up
+  adminer:
+    image: adminer:latest
+    container_name: polymarket-adminer
+    ports:
+      - "${ADMINER_PORT:-8080}:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    profiles:
+      - tools
+    restart: unless-stopped
+
+  redis-insight:
+    image: redis/redisinsight:latest
+    container_name: polymarket-redis-insight
+    ports:
+      - "${REDIS_INSIGHT_PORT:-5540}:5540"
+    volumes:
+      - redis_insight_data:/data
+    depends_on:
+      redis:
+        condition: service_healthy
+    profiles:
+      - tools
+    restart: unless-stopped
+
+volumes:
+  postgres_data:
+    driver: local
+  redis_data:
+    driver: local
+  redis_insight_data:
+    driver: local


### PR DESCRIPTION
## Summary
- Add `docker-compose.yml` with PostgreSQL 15 and Redis 7 services
- Both services have health checks and persistent volumes
- Add optional development tools (Adminer, RedisInsight) via `tools` profile
- Create `.env.example` with all configuration variables
- Update `README.md` with Docker setup documentation

## Changes

### docker-compose.yml
- **PostgreSQL 15**: Primary database with health checks, persistent volume
- **Redis 7**: Caching layer with AOF persistence, health checks
- **Adminer**: Optional database admin UI (port 8080)
- **RedisInsight**: Optional Redis admin UI (port 5540)

### .env.example
- PostgreSQL configuration variables
- Redis configuration variables
- Optional dev tool port configuration
- Polygon RPC and Polymarket API settings
- Alert webhook placeholders

### README.md
- Docker Services table with ports and descriptions
- Docker Compose commands for common operations
- Instructions for starting with/without dev tools

## Test plan
- [x] Docker Compose validates (`docker compose config`)
- [x] Environment variables properly templated
- [x] Health checks configured for critical services

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)