### PR TITLE
fix: resolve flaky tests in clob_client and websocket (#49)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -127,6 +127,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "alembic"
 version = "1.17.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1548,6 +1557,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "aiosqlite" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -1559,6 +1569,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
+    { name = "aiosqlite", marker = "extra == 'dev'", specifier = ">=0.19.0" },
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7.0" },


### PR DESCRIPTION
## Summary

- Fixed `test_get_market_not_found` to expect `RetryError` instead of `ClobClientError` (retry logic wraps exceptions)
- Fixed `test_start_and_receive_trades` by replacing `MagicMock` with a proper async iterable class

## Root Causes

### test_get_market_not_found
The `get_market` method has the `@with_retry()` decorator applied. When the underlying API call fails, the retry logic retries the operation, and after exhausting retries, raises `RetryError` wrapping the original exception - not `ClobClientError`.

### test_start_and_receive_trades
The mock WebSocket's `__aiter__` was improperly set up. When `MagicMock` calls a method assigned as an attribute, it passes `self` (the mock) as the first argument. This caused "takes 0 positional arguments but 1 was given" errors. The fix uses a proper `MockWebSocket` class that correctly implements the async iterator protocol.

## Test plan
- [x] Both previously failing tests now pass
- [x] All 581 tests pass
- [x] Ruff linting passes

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)