### PR TITLE
fix: resolve all mypy type errors for strict type checking (#48)

### DIFF
--- a/src/polymarket_insider_tracker/alerter/formatter.py
+++ b/src/polymarket_insider_tracker/alerter/formatter.py
@@ -190,10 +190,11 @@ class AlertFormatter:
         wallet_age_str = ""
         if assessment.fresh_wallet_signal:
             age_hours = assessment.fresh_wallet_signal.wallet_profile.age_hours
-            if age_hours < 1:
-                wallet_age_str = f" (Age: {int(age_hours * 60)}m)"
-            else:
-                wallet_age_str = f" (Age: {age_hours:.0f}h)"
+            if age_hours is not None:
+                if age_hours < 1:
+                    wallet_age_str = f" (Age: {int(age_hours * 60)}m)"
+                else:
+                    wallet_age_str = f" (Age: {age_hours:.0f}h)"
 
         fields: list[dict[str, object]] = [
             {
@@ -282,10 +283,11 @@ class AlertFormatter:
         wallet_line = f"*Wallet:* `{wallet_short}`"
         if assessment.fresh_wallet_signal:
             age_hours = assessment.fresh_wallet_signal.wallet_profile.age_hours
-            if age_hours < 1:
-                wallet_line += f" \\(Age: {int(age_hours * 60)}m\\)"
-            else:
-                wallet_line += f" \\(Age: {age_hours:.0f}h\\)"
+            if age_hours is not None:
+                if age_hours < 1:
+                    wallet_line += f" \\(Age: {int(age_hours * 60)}m\\)"
+                else:
+                    wallet_line += f" \\(Age: {age_hours:.0f}h\\)"
         lines.append(wallet_line)
 
         # Risk score
@@ -366,10 +368,11 @@ class AlertFormatter:
         wallet_line = f"Wallet: {wallet_short}"
         if assessment.fresh_wallet_signal:
             age_hours = assessment.fresh_wallet_signal.wallet_profile.age_hours
-            if age_hours < 1:
-                wallet_line += f" (Age: {int(age_hours * 60)}m)"
-            else:
-                wallet_line += f" (Age: {age_hours:.0f}h)"
+            if age_hours is not None:
+                if age_hours < 1:
+                    wallet_line += f" (Age: {int(age_hours * 60)}m)"
+                else:
+                    wallet_line += f" (Age: {age_hours:.0f}h)"
         lines.append(wallet_line)
 
         # Risk

--- a/src/polymarket_insider_tracker/alerter/history.py
+++ b/src/polymarket_insider_tracker/alerter/history.py
@@ -362,7 +362,7 @@ class AlertHistory:
             start.timestamp(),
             end.timestamp(),
         )
-        return count
+        return int(count)
 
     async def cleanup_old_alerts(self) -> int:
         """Remove alerts older than retention period.
@@ -393,4 +393,4 @@ class AlertHistory:
         # Note: Individual alert records will expire via TTL
         # Wallet/market indexes will also expire via TTL
         logger.info(f"Cleaned up {removed} old alert references")
-        return removed
+        return int(removed)

--- a/src/polymarket_insider_tracker/detector/scorer.py
+++ b/src/polymarket_insider_tracker/detector/scorer.py
@@ -268,7 +268,7 @@ class RiskScorer:
         """
         key = f"{self._key_prefix}{wallet_address}:{market_id}"
         deleted = await self._redis.delete(key)
-        return deleted > 0
+        return int(deleted) > 0
 
     async def assess_batch(self, bundles: list[SignalBundle]) -> list[RiskAssessment]:
         """Assess multiple trade bundles.

--- a/src/polymarket_insider_tracker/ingestor/clob_client.py
+++ b/src/polymarket_insider_tracker/ingestor/clob_client.py
@@ -287,7 +287,8 @@ class ClobClient:
 
         try:
             response = self._client.get_midpoint(token_id)
-            return response.get("mid")
+            mid = response.get("mid")
+            return str(mid) if mid is not None else None
         except Exception as e:
             logger.warning("Failed to get midpoint for %s: %s", token_id, e)
             return None
@@ -307,7 +308,8 @@ class ClobClient:
 
         try:
             response = self._client.get_price(token_id, side=side)
-            return response.get("price")
+            price = response.get("price")
+            return str(price) if price is not None else None
         except Exception as e:
             logger.warning("Failed to get %s price for %s: %s", side, token_id, e)
             return None
@@ -321,7 +323,7 @@ class ClobClient:
         try:
             self._rate_limiter.acquire_sync()
             result = self._client.get_ok()
-            return result == "OK"
+            return str(result) == "OK"
         except Exception as e:
             logger.error("Health check failed: %s", e)
             return False
@@ -334,7 +336,8 @@ class ClobClient:
         """
         try:
             self._rate_limiter.acquire_sync()
-            return self._client.get_server_time()
+            result = self._client.get_server_time()
+            return int(result) if result is not None else None
         except Exception as e:
             logger.error("Failed to get server time: %s", e)
             return None

--- a/src/polymarket_insider_tracker/ingestor/metadata_sync.py
+++ b/src/polymarket_insider_tracker/ingestor/metadata_sync.py
@@ -351,7 +351,7 @@ class MarketMetadataSync:
         """
         key = f"{self._key_prefix}{condition_id}"
         deleted = await self._redis.delete(key)
-        return deleted > 0
+        return int(deleted) > 0
 
     async def force_sync(self) -> None:
         """Force an immediate sync of all markets.

--- a/src/polymarket_insider_tracker/profiler/funding.py
+++ b/src/polymarket_insider_tracker/profiler/funding.py
@@ -232,6 +232,7 @@ class FundingTracer:
         )
 
         # Get logs with Transfer event filtering by recipient
+        # Note: web3 typing is overly restrictive for block params
         logs = await w3.eth.get_logs(
             {
                 "address": AsyncWeb3.to_checksum_address(token_address),
@@ -240,8 +241,8 @@ class FundingTracer:
                     None,  # from (any)
                     padded_to,  # to (target address)
                 ],
-                "fromBlock": from_block,
-                "toBlock": to_block,
+                "fromBlock": from_block,  # type: ignore[typeddict-item]
+                "toBlock": to_block,  # type: ignore[typeddict-item]
             }
         )
 
@@ -317,7 +318,7 @@ class FundingTracer:
                     origin_type="error",
                 )
             else:
-                chains[addr.lower()] = result  # type: ignore[assignment]
+                chains[addr.lower()] = result
 
         return chains
 


### PR DESCRIPTION
## Summary

- Fixed all 30 mypy type errors across 8 files
- Enables strict type checking in CI

## Fixes Applied

### `no-any-return` errors
- Cast Redis/API returns to proper types (int, str, bool)
- Affected files: `alerter/history.py`, `ingestor/clob_client.py`, `ingestor/publisher.py`, `ingestor/metadata_sync.py`, `detector/scorer.py`

### `operator` errors
- Added null checks for optional `age_hours` in `alerter/formatter.py`

### External library typing issues
- `redis-py`: xadd dict parameter type mismatch
- `web3`: Block parameter types overly restrictive
- `SQLAlchemy`: Result.rowcount not in typing

### `assignment` errors
- Renamed SQLite insert statement variable to avoid type conflict

## Test plan
- [x] All 581 tests pass
- [x] mypy src/ passes with no errors
- [x] ruff check src/ passes

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)