### PR TITLE
fix: load nested env settings and ignore blank webhooks

### DIFF
--- a/src/polymarket_insider_tracker/config.py
+++ b/src/polymarket_insider_tracker/config.py
@@ -18,7 +18,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class DatabaseSettings(BaseSettings):
     """Database connection settings."""
 
-    model_config = SettingsConfigDict(env_prefix="")
+    model_config = SettingsConfigDict(env_prefix="", env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
     url: str = Field(
         alias="DATABASE_URL",
@@ -37,7 +37,7 @@ class DatabaseSettings(BaseSettings):
 class RedisSettings(BaseSettings):
     """Redis connection settings."""
 
-    model_config = SettingsConfigDict(env_prefix="")
+    model_config = SettingsConfigDict(env_prefix="", env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
     url: str = Field(
         default="redis://localhost:6379",
@@ -57,7 +57,7 @@ class RedisSettings(BaseSettings):
 class PolygonSettings(BaseSettings):
     """Polygon blockchain RPC settings."""
 
-    model_config = SettingsConfigDict(env_prefix="POLYGON_")
+    model_config = SettingsConfigDict(env_prefix="POLYGON_", env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
     rpc_url: str = Field(
         default="https://polygon-rpc.com",
@@ -84,7 +84,7 @@ class PolygonSettings(BaseSettings):
 class PolymarketSettings(BaseSettings):
     """Polymarket API settings."""
 
-    model_config = SettingsConfigDict(env_prefix="POLYMARKET_")
+    model_config = SettingsConfigDict(env_prefix="POLYMARKET_", env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
     ws_url: str = Field(
         default="wss://ws-subscriptions-clob.polymarket.com/ws/market",
@@ -109,7 +109,7 @@ class PolymarketSettings(BaseSettings):
 class DiscordSettings(BaseSettings):
     """Discord notification settings."""
 
-    model_config = SettingsConfigDict(env_prefix="DISCORD_")
+    model_config = SettingsConfigDict(env_prefix="DISCORD_", env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
     webhook_url: SecretStr | None = Field(
         default=None,
@@ -120,13 +120,13 @@ class DiscordSettings(BaseSettings):
     @property
     def enabled(self) -> bool:
         """Check if Discord notifications are enabled."""
-        return self.webhook_url is not None
+        return self.webhook_url is not None and bool(self.webhook_url.get_secret_value().strip())
 
 
 class TelegramSettings(BaseSettings):
     """Telegram notification settings."""
 
-    model_config = SettingsConfigDict(env_prefix="TELEGRAM_")
+    model_config = SettingsConfigDict(env_prefix="TELEGRAM_", env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
     bot_token: SecretStr | None = Field(
         default=None,
@@ -142,7 +142,7 @@ class TelegramSettings(BaseSettings):
     @property
     def enabled(self) -> bool:
         """Check if Telegram notifications are enabled."""
-        return self.bot_token is not None and self.chat_id is not None
+        return self.bot_token is not None and bool(self.bot_token.get_secret_value().strip()) and self.chat_id is not None and bool(self.chat_id.strip())
 
 
 class Settings(BaseSettings):


### PR DESCRIPTION
This upstreams the config fixes from my earlier runtime work.

Included:
- load nested Pydantic settings from .env for each settings group
- ignore blank Discord webhook values instead of treating them as enabled
- ignore blank Telegram token/chat values instead of treating them as enabled
- update config tests to match the new behavior

This intentionally excludes the separate CLOB retry/backoff changes from the same earlier branch.