### PR TITLE
fix: subscribe to trades on RTDS endpoint with action: subscribe (#89)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ POLYGON_RPC_URL=https://polygon-rpc.com
 POLYGON_FALLBACK_RPC_URL=https://polygon-bor.publicnode.com
 
 # Polymarket API Configuration
-POLYMARKET_WS_URL=wss://ws-subscriptions-clob.polymarket.com/ws/market
+POLYMARKET_WS_URL=wss://ws-live-data.polymarket.com
 
 # Alert Webhooks (optional)
 DISCORD_WEBHOOK_URL=

--- a/src/polymarket_insider_tracker/config.py
+++ b/src/polymarket_insider_tracker/config.py
@@ -87,7 +87,7 @@ class PolymarketSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="POLYMARKET_", env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
     ws_url: str = Field(
-        default="wss://ws-subscriptions-clob.polymarket.com/ws/market",
+        default="wss://ws-live-data.polymarket.com",
         alias="POLYMARKET_WS_URL",
         description="Polymarket WebSocket URL for live data",
     )

--- a/src/polymarket_insider_tracker/ingestor/websocket.py
+++ b/src/polymarket_insider_tracker/ingestor/websocket.py
@@ -150,7 +150,7 @@ class TradeStreamHandler:
         elif self._market_filter:
             subscription["filters"] = json.dumps({"market_slug": self._market_filter})
 
-        return {"subscriptions": [subscription]}
+        return {"action": "subscribe", "subscriptions": [subscription]}
 
     async def _connect(self) -> ClientConnection:
         """Establish WebSocket connection."""


### PR DESCRIPTION
## Problem

The pipeline reports `Connected ... and subscribed to trades` but no trade event is ever delivered. Two related causes:

### 1. Wrong endpoint

`config.py` default and `.env.example` set:

```
POLYMARKET_WS_URL=wss://ws-subscriptions-clob.polymarket.com/ws/market
```

That is the **CLOB market channel**. Per the Polymarket docs (`docs.polymarket.com/developers/CLOB/websocket/wss-overview`) it streams orderbook events only — `book`, `price_change`, `tick_size_change`, `last_trade_price`, `best_bid_ask`, `new_market`, `market_resolved`. There is no `activity/trades` topic on this channel.

Public trade activity lives on the RTDS endpoint `wss://ws-live-data.polymarket.com`, which is what `websocket.py:21` already declares as `DEFAULT_WS_HOST` (currently unused because `pipeline.py` overrides with `settings.polymarket.ws_url`).

### 2. Missing `action: subscribe` field

RTDS protocol (per `docs.polymarket.com/developers/RTDS/RTDS-overview` and `Polymarket/real-time-data-client` README) requires the top-level `action` field. Without it the server accepts the WS connection but silently drops the subscription request:

```json
{
  "action": "subscribe",
  "subscriptions": [{"topic": "activity", "type": "trades"}]
}
```

## Fix

- `_build_subscription_message`: add `\"action\": \"subscribe\"` to the dict
- `config.py` `PolymarketSettings.ws_url` default → `wss://ws-live-data.polymarket.com`
- `.env.example`: same default

`type` stays `\"trades\"` (not `\"orders_matched\"` as #89 proposes): the trades payload schema matches `TradeEvent.from_websocket_message` exactly (`conditionId`, `proxyWallet`, `asset`, `outcome`, `outcomeIndex`, `side`, `size`, `price`, `transactionHash`). Switching to `orders_matched` would require a new parser.

## Verification

Verified live (2026-05-06) with raw `websockets` client: 4 trade messages within seconds, fields match `TradeEvent`. After the fix the tracker logs continuous `detector.size_anomaly` signals as live trades flow through.

Closes #89 (partially — `action` portion; `orders_matched` intentionally not adopted, see above).