### PR TITLE
fix: coerce DATABASE_URL to async driver inside create_async_db_engine

### DIFF
--- a/src/polymarket_insider_tracker/storage/database.py
+++ b/src/polymarket_insider_tracker/storage/database.py
@@ -37,17 +37,33 @@ def create_sync_engine(database_url: str, **kwargs: Any) -> Engine:
     return create_engine(database_url, **kwargs)
 
 
+def _ensure_async_driver(database_url: str) -> str:
+    """Coerce a generic postgresql:// URL to postgresql+asyncpg://.
+
+    SQLAlchemy's create_async_engine refuses URLs whose dialect resolves to a
+    sync driver. The same DATABASE_URL is consumed by both alembic (sync) and
+    the application (async), so a single canonical postgresql:// value must
+    work for both. Rewrite to the asyncpg driver here so callers can pass the
+    canonical URL unchanged.
+    """
+    if database_url.startswith("postgresql://"):
+        return "postgresql+asyncpg://" + database_url[len("postgresql://") :]
+    return database_url
+
+
 def create_async_db_engine(database_url: str, **kwargs: Any) -> AsyncEngine:
     """Create an asynchronous SQLAlchemy engine.
 
     Args:
-        database_url: Database connection URL (e.g., postgresql+asyncpg://...).
+        database_url: Database connection URL. Either ``postgresql://...`` or
+            ``postgresql+asyncpg://...`` is accepted; the former is rewritten
+            to use the asyncpg driver.
         **kwargs: Additional engine options.
 
     Returns:
         SQLAlchemy AsyncEngine instance.
     """
-    return create_async_engine(database_url, **kwargs)
+    return create_async_engine(_ensure_async_driver(database_url), **kwargs)
 
 
 def create_sync_session_factory(engine: Engine) -> sessionmaker[Session]:


### PR DESCRIPTION
## Problem

The same `DATABASE_URL` env var is consumed by two callers:

1. `alembic/env.py` uses sync `engine_from_config` → requires a sync-driver URL (a bare `postgresql://...` resolves to psycopg2)
2. `pipeline.py:210` builds `DatabaseManager(..., async_mode=True)` which calls `create_async_engine(url)` → requires an **async** driver URL (`postgresql+asyncpg://...`)

Per SQLAlchemy, `create_async_engine` refuses a URL whose dialect resolves to a sync driver:

```
InvalidArgumentError: The asyncio extension requires an async driver to be used.
```

So a single `DATABASE_URL` can't satisfy both: pick one prefix, the other call site breaks. `.env.example` currently documents `postgresql://...`, which means `alembic upgrade head` works but `python -m polymarket_insider_tracker` crashes at startup. Flipping the example to `postgresql+asyncpg://` would just move the failure to alembic.

## Fix

Coerce the URL to use the asyncpg driver inside `create_async_db_engine` itself. Both `postgresql://...` and `postgresql+asyncpg://...` are accepted on input. Alembic keeps receiving the canonical `postgresql://` URL untouched.

```python
def _ensure_async_driver(database_url: str) -> str:
    if database_url.startswith("postgresql://"):
        return "postgresql+asyncpg://" + database_url[len("postgresql://"):]
    return database_url
```

Single point of substitution, no Dockerfile/CI hack required.

## Verification

End-to-end against a Postgres 15 container with the canonical URL from `.env.example`:

```
DATABASE_URL=postgresql://tracker:dev_password@postgres:5432/polymarket_tracker
```

- `alembic upgrade head` → applies `001_initial` migration cleanly
- `python -m polymarket_insider_tracker` → connects, completes metadata sync, transitions pipeline to RUNNING, processes live trades

## Files

- `src/polymarket_insider_tracker/storage/database.py`

## Notes

Pairs naturally with #96 (which adds `asyncpg` and `psycopg2-binary` to dependencies). With this PR plus #96, the documented `.env.example` value works out of the box for both alembic and the app, no manual URL juggling.