### PR TITLE
fix: short-circuit get_market when conditionId is empty

### DIFF
--- a/src/polymarket_insider_tracker/ingestor/metadata_sync.py
+++ b/src/polymarket_insider_tracker/ingestor/metadata_sync.py
@@ -285,6 +285,13 @@ class MarketMetadataSync:
         Returns:
             MarketMetadata if found, None otherwise.
         """
+        # Some RTDS activity/trades events arrive without a conditionId
+        # (e.g. sport markets). Skip them rather than calling the CLOB
+        # /markets/ endpoint with an empty path segment, which 301-redirects
+        # to /markets and triggers retry storms.
+        if not condition_id:
+            return None
+
         # Try cache first
         key = f"{self._key_prefix}{condition_id}"
         cached = await self._redis.get(key)


### PR DESCRIPTION
## Problem

Some RTDS `activity/trades` messages arrive without a `conditionId` (e.g. sport markets and other non-CTF events). `TradeEvent.from_websocket_message` defaults the missing field to `""`, and the `size_anomaly` detector then calls `metadata_sync.get_market("")` for every such trade.

That ends up calling `clob.polymarket.com/markets/` — note the trailing slash with no id — which 301-redirects to `/markets`. `py_clob_client` treats the redirect as a hard error, and the `with_retry` decorator hits it 4 times before giving up:

```
Attempt 2/4 failed: Failed to fetch market : PolyApiException
  [status_code=301, error_message=<a href="/markets">Moved Permanently</a>
```

Result: per-trade burst of warnings and 4 wasted HTTP round-trips for every conditionId-less trade. Observed 32 such errors during a ~10 min production window.

## Fix

Skip the CLOB call when `condition_id` is empty and return `None`, the contract `get_market()` already uses for any other miss.

```python
async def get_market(self, condition_id: str) -> MarketMetadata | None:
    if not condition_id:
        return None
    ...
```

## Verification

After the patch, 0 `Failed to fetch market` warnings during a 2 min window with normal trade volume; signal generation continues uninterrupted.

## Files

- `src/polymarket_insider_tracker/ingestor/metadata_sync.py`