### PR TITLE
fix(ingestor): subscribe via action:subscribe and route by payload shape

### DIFF
--- a/src/polymarket_insider_tracker/ingestor/websocket.py
+++ b/src/polymarket_insider_tracker/ingestor/websocket.py
@@ -150,7 +150,7 @@ class TradeStreamHandler:
         elif self._market_filter:
             subscription["filters"] = json.dumps({"market_slug": self._market_filter})
 
-        return {"subscriptions": [subscription]}
+        return {"action": "subscribe", "subscriptions": [subscription]}
 
     async def _connect(self) -> ClientConnection:
         """Establish WebSocket connection."""
@@ -183,12 +183,9 @@ class TradeStreamHandler:
         try:
             data = json.loads(message)
 
-            # Check if this is a trade message
-            topic = data.get("topic")
-            msg_type = data.get("type")
-
-            if topic == "activity" and msg_type == "trades":
-                payload = data.get("payload", {})
+            # ws-live-data pushes {connection_id, payload:{...trade fields}}
+            payload = data.get("payload")
+            if isinstance(payload, dict) and "transactionHash" in payload and "proxyWallet" in payload:
                 trade = TradeEvent.from_websocket_message(payload)
 
                 self._stats.trades_received += 1
@@ -208,8 +205,7 @@ class TradeStreamHandler:
                     logger.error("Error in trade callback: %s", e)
 
             else:
-                # Log other message types for debugging
-                logger.debug("Received message: topic=%s type=%s", topic, msg_type)
+                logger.debug("Received non-trade message: %s", str(data)[:120])
 
         except json.JSONDecodeError as e:
             logger.warning("Invalid JSON message: %s", e)

--- a/tests/ingestor/test_websocket.py
+++ b/tests/ingestor/test_websocket.py
@@ -84,7 +84,10 @@ class TestTradeStreamHandler:
         """Test building subscription message without filters."""
         msg = handler._build_subscription_message()
 
-        assert msg == {"subscriptions": [{"topic": "activity", "type": "trades"}]}
+        assert msg == {
+            "action": "subscribe",
+            "subscriptions": [{"topic": "activity", "type": "trades"}],
+        }
 
     def test_build_subscription_message_with_event_filter(self, on_trade_mock: AsyncMock) -> None:
         """Test building subscription message with event filter."""


### PR DESCRIPTION
## Summary

The Polymarket live-data WebSocket protocol requires every subscribe frame to carry an explicit `action: "subscribe"` envelope. Without it the server accepts the connection but never delivers trade events, so the tracker silently produces zero alerts in production.

Additionally, the actual frames pushed back by `ws-live-data` are shaped `{connection_id, payload: {...trade fields}}` — they do NOT echo the `topic` / `type` keys we sent. The previous routing check (`topic == "activity" and msg_type == "trades"`) therefore matched nothing and every real trade was silently dropped onto the debug "non-trade" branch.

## Changes

- Add `"action": "subscribe"` to the outgoing subscribe frame
- Route incoming messages by inspecting `payload` for the `transactionHash` + `proxyWallet` keys that identify a trade event
- Update `test_build_subscription_message_no_filter` to match

## Test plan

- [x] `pytest tests/ingestor/test_websocket.py` — 18 passed
- [x] Verified end-to-end on a JP VPS deployment: after this fix the tracker goes from 0 trades/min to ~30-100 trades/min and starts producing real Telegram alerts at the default 0.6 risk threshold