### PR TITLE
fix(alerter): escape all dynamic numeric fields in Telegram MarkdownV2

### DIFF
--- a/src/polymarket_insider_tracker/alerter/formatter.py
+++ b/src/polymarket_insider_tracker/alerter/formatter.py
@@ -290,12 +290,14 @@ class AlertFormatter:
                     wallet_line += f" \\(Age: {age_hours:.0f}h\\)"
         lines.append(wallet_line)
 
-        # Risk score
-        lines.append(f"*Risk Score:* {assessment.weighted_score:.2f} \\({risk_level}\\)")
+        # Risk score — every numeric literal here must be escaped because
+        # MarkdownV2 treats `.` as a special character and rejects unescaped
+        # ones with `Bad Request: can't parse entities`.
+        score_str = self._escape_telegram_markdown(f"{assessment.weighted_score:.2f}")
+        lines.append(f"*Risk Score:* {score_str} \\({risk_level}\\)")
 
         # Market
         market_title = trade.event_title or trade.market_slug or "Unknown Market"
-        # Escape special Telegram markdown characters
         market_title_escaped = self._escape_telegram_markdown(market_title)
         if "market" in links:
             lines.append(f"*Market:* [{market_title_escaped}]({links['market']})")
@@ -303,14 +305,19 @@ class AlertFormatter:
             lines.append(f"*Market:* {market_title_escaped}")
 
         # Trade details
-        usdc_value = format_usdc(trade.notional_value).replace("$", "\\$")
+        usdc_value = self._escape_telegram_markdown(format_usdc(trade.notional_value))
+        price_str = self._escape_telegram_markdown(f"{trade.price:.3f}")
+        side_escaped = self._escape_telegram_markdown(trade.side)
+        outcome_escaped = self._escape_telegram_markdown(trade.outcome)
         lines.append(
-            f"*Trade:* {trade.side} {trade.outcome} @ \\${trade.price:.3f} \\| {usdc_value}"
+            f"*Trade:* {side_escaped} {outcome_escaped} "
+            f"@ \\${price_str} \\| {usdc_value}"
         )
 
         # Signals
         if signals:
-            lines.append(f"*Signals:* {', '.join(signals)}")
+            signals_escaped = [self._escape_telegram_markdown(s) for s in signals]
+            lines.append(f"*Signals:* {', '.join(signals_escaped)}")
 
         # Links
         lines.append("")

--- a/tests/alerter/test_formatter.py
+++ b/tests/alerter/test_formatter.py
@@ -409,11 +409,29 @@ class TestTelegramMarkdown:
         assert "`0x1234...5678`" in result.telegram_markdown
 
     def test_telegram_includes_risk_score(self, high_risk_assessment: RiskAssessment) -> None:
-        """Test that Telegram message includes risk score."""
+        """Test that Telegram message includes risk score, MarkdownV2-escaped."""
         formatter = AlertFormatter()
         result = formatter.format(high_risk_assessment)
-        assert "0.82" in result.telegram_markdown
+        # MarkdownV2 requires `.` to be escaped, so 0.82 becomes 0\.82.
+        assert "0\\.82" in result.telegram_markdown
         assert "HIGH" in result.telegram_markdown
+
+    def test_telegram_escapes_all_decimals(
+        self, high_risk_assessment: RiskAssessment
+    ) -> None:
+        """Telegram MarkdownV2 rejects unescaped `.` in dynamic numeric
+        fields (risk score, price, USDC amount). All must be present in
+        their escaped form."""
+        formatter = AlertFormatter()
+        result = formatter.format(high_risk_assessment)
+        md = result.telegram_markdown
+        for unescaped in ("0.82", "0.075", "15,000.00"):
+            assert unescaped not in md, (
+                f"unescaped {unescaped!r} would be rejected by Telegram MarkdownV2:"
+                f" {md!r}"
+            )
+        for escaped in ("0\\.82", "0\\.075", "15,000\\.00"):
+            assert escaped in md, f"missing escaped {escaped!r} in {md!r}"
 
     def test_telegram_includes_links(self, high_risk_assessment: RiskAssessment) -> None:
         """Test that Telegram message includes links."""


### PR DESCRIPTION
## Summary
Routes every dynamic value in the Telegram message body through `_escape_telegram_markdown` before interpolation, so the parser doesn't reject valid alerts because of an unescaped `.`.

## Bug
Telegram MarkdownV2 treats `.` as a special character and returns `400 Bad Request: can't parse entities` if any unescaped `.` appears outside a code/pre block. Today the formatter escapes only the static `Market:` title and the `$` in the USDC amount, leaving three numeric runs unescaped:

```
*Risk Score:* 0.82 (HIGH)             ← `.` in score literal
*Trade:* BUY Yes @ $0.075 | $15,000.00
                     ↑                  ↑
                     price              USDC amount
```

In production this silently drops well-formed alerts — the dispatcher gets a 400 and the event never reaches the user.

## Fix
The dynamic fields now go through the existing `_escape_telegram_markdown` helper:

- `assessment.weighted_score`
- `trade.price`
- `format_usdc(trade.notional_value)` (including its internal `.`)
- `trade.side` and `trade.outcome` (defensive — upstream may add `-` or `.` in future schema changes)

The static literals (`*Risk Score:*`, `\(`, `\|`, etc.) are unchanged.

## Test plan
- [x] Existing `test_telegram_includes_risk_score` updated to require the escaped form `0\.82` (the prior `"0.82" in markdown` assertion was effectively confirming the bug).
- [x] New `test_telegram_escapes_all_decimals` pins down that none of `0.82` / `0.075` / `15,000.00` appear in unescaped form, and that their escaped counterparts do.
- [x] `pytest tests/alerter/` → 43 passed.
- [x] Manually verified against live Telegram Bot API: the message now renders cleanly instead of returning `Bad Request: can't parse entities`.