### PR TITLE
chore: enforce Black formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,11 @@ repos:
     hooks:
       - id: ruff
         args: [--fix]
-      - id: ruff-format
+
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 26.5.1
+    hooks:
+      - id: black
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.8.0

--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ uv run --env-file .env python scripts/verify.py --profile services
 uv run --env-file .env python scripts/verify.py --profile all
 ```
 
-The `static` profile checks the lock, formatting, lint, and strict mypy.
+The `static` profile checks the lock, Black formatting across the repository, Ruff lint/import rules,
+and strict mypy.
 The `compatibility` profile checks locked imports and the deterministic test suite. The `services`
 profile performs real local probes and the disposable migration cycle. Individual commands remain
 visible in verifier output and `--help`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "black==26.5.1",
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0.0",
@@ -43,6 +44,11 @@ required-version = ">=0.11,<0.12"
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+
+# Black is the repository's formatting authority; Ruff remains the lint and import-rule engine.
 [tool.ruff]
 line-length = 100
 target-version = "py311"
@@ -61,7 +67,7 @@ select = [
     "SIM",    # flake8-simplify
 ]
 ignore = [
-    "E501",   # line too long (handled by formatter)
+    "E501",   # line too long (handled by Black)
 ]
 
 [tool.ruff.lint.isort]

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -75,9 +75,7 @@ Runner = Callable[[Gate], CommandExecution]
 
 GATES: Mapping[str, Gate] = {
     "lock": Gate("lock", ("uv", "lock", "--check")),
-    "format": Gate(
-        "format", (sys.executable, "-m", "ruff", "format", "--check", "src", "tests", "scripts")
-    ),
+    "format": Gate("format", (sys.executable, "-m", "black", "--check", ".")),
     "lint": Gate("lint", (sys.executable, "-m", "ruff", "check", "src", "tests", "scripts")),
     "strict-types": Gate(
         "strict-types",
@@ -150,7 +148,7 @@ _URL_PATTERN = re.compile(
 # Direct equivalents of every aggregate gate, kept literal so contributors can copy them verbatim.
 DIRECT_GATE_COMMANDS: tuple[tuple[str, str], ...] = (
     ("lock", "uv lock --check"),
-    ("format", "uv run ruff format --check src tests scripts"),
+    ("format", "uv run black --check ."),
     ("lint", "uv run ruff check src tests scripts"),
     ("strict-types", "uv run --isolated --locked --all-extras --python 3.11 mypy"),
     (

--- a/specs/002-reproducible-runtime/contracts/runtime-verification.md
+++ b/specs/002-reproducible-runtime/contracts/runtime-verification.md
@@ -12,12 +12,12 @@ uv run python scripts/verify.py --profile PROFILE [--json]
 
 | Profile | Required gates | Intended caller |
 |---|---|---|
-| `static` | lock freshness, format, lint, strict mypy | Contributor and Linux quality job |
+| `static` | lock freshness, Black formatting, Ruff lint/import rules, strict mypy | Contributor and Linux quality job |
 | `compatibility` | lock freshness, dependency/import smoke, full deterministic pytest suite | Linux version matrix and advisory Apple job |
 | `services` | `services` connectivity/async-query gate, then independent `migrations` disposable-cycle gate | Linux service job and local release evidence |
 | `all` | Every gate above, without duplicate execution | Contributor pre-review/release evidence |
 
-Individual Ruff, mypy, pytest, and Alembic commands remain directly runnable and are
+Individual Black, Ruff, mypy, pytest, and Alembic commands remain directly runnable and are
 listed by `--help`; the aggregate entry point does not hide their output.
 
 The aggregate `tests` gate removes application and service configuration inherited from a loaded `.env`

--- a/specs/002-reproducible-runtime/plan.md
+++ b/specs/002-reproducible-runtime/plan.md
@@ -19,7 +19,7 @@ entry point for a blocking Linux matrix and service job plus an advisory Apple S
 **Language/Version**: CPython 3.11, 3.12, and 3.13; lowest supported syntax remains Python 3.11
 
 **Primary Dependencies**: uv `>=0.11,<0.12` project/lock workflow; SQLAlchemy 2.x with its `asyncio`
-extra; Psycopg 3 with binary distribution; Alembic 1.x; redis-py 5+; pytest, Ruff, and mypy
+extra; Psycopg 3 with binary distribution; Alembic 1.x; redis-py 5+; pytest, Black, Ruff, and mypy
 
 **Storage**: PostgreSQL 15 and Redis 7; no persisted schema change in this slice
 
@@ -121,7 +121,7 @@ modules. No new service, package, or migration is needed.
 - Change `requires-python` and the lock boundary to `>=3.11,<3.14`.
 - Declare `[tool.uv] required-version = ">=0.11,<0.12"`; CI installs a reviewed exact uv 0.11 release,
   while the repository contract rejects unsupported uv versions.
-- Keep Ruff and mypy configured for Python 3.11 because it is the minimum accepted syntax/API level.
+- Keep Black, Ruff, and mypy configured for Python 3.11 because it is the minimum accepted syntax/API level.
 - Keep each runtime declaration in its native authority: package support in `pyproject.toml`, resolved
   support in `uv.lock`, executable platform evidence in CI, and contributor guidance in `README.md`.
   Validate those surfaces through their real consumers instead of reparsing them in a bespoke checker.

--- a/specs/002-reproducible-runtime/quickstart.md
+++ b/specs/002-reproducible-runtime/quickstart.md
@@ -30,7 +30,7 @@ Expected result:
 - PostgreSQL and Redis answer real probes;
 - migrations reach head, downgrade one revision in a disposable database, return to head, and clean up;
 - an asynchronous query succeeds through the same canonical database URL;
-- lock, format, lint, strict type, and deterministic test gates all pass;
+- lock, Black format, Ruff lint, strict type, and deterministic test gates all pass;
 - the aggregate process exits `0` without contacting external market, chain, or notification services.
 
 The normal application database named in `.env` is never downgraded or dropped.
@@ -78,7 +78,7 @@ On Apple Silicon, record `uname -m` with release evidence and require `arm64`. T
   service is contacted.
 - Non-loopback or malformed database URL for `services`: exit `2` before creating or migrating a database.
 - Missing PostgreSQL/Redis: exit `1`, name the unreachable service, and print no credential-bearing URL.
-- Any Ruff, mypy, pytest, service, or migration failure: aggregate exit is nonzero; later gates are not run.
+- Any Black, Ruff, mypy, pytest, service, or migration failure: aggregate exit is nonzero; later gates are not run.
 
 ## Cleanup
 

--- a/src/polymarket_insider_tracker/detector/sniper.py
+++ b/src/polymarket_insider_tracker/detector/sniper.py
@@ -228,17 +228,12 @@ class SniperDetector:
             for entry in entries:
                 # Normalize market ID to 0-1 range
                 market_hash = (
-                    (
-                        int(
-                            hashlib.md5(  # noqa: S324
-                                entry.market_id.encode()
-                            ).hexdigest()[:8],
-                            16,
-                        )
-                        % 1000
+                    int(
+                        hashlib.md5(entry.market_id.encode()).hexdigest()[:8],  # noqa: S324
+                        16,
                     )
-                    / 1000.0
-                )
+                    % 1000
+                ) / 1000.0
 
                 # Normalize entry delta to hours (0-5 mins = 0-0.083 hours)
                 delta_hours = entry.entry_delta_seconds / 3600.0

--- a/src/polymarket_insider_tracker/ingestor/health.py
+++ b/src/polymarket_insider_tracker/ingestor/health.py
@@ -337,9 +337,7 @@ class HealthMonitor:
         HEALTH_STATUS.set(
             1.0
             if overall_status == HealthStatus.HEALTHY
-            else 0.5
-            if overall_status == HealthStatus.DEGRADED
-            else 0.0
+            else 0.5 if overall_status == HealthStatus.DEGRADED else 0.0
         )
 
         uptime = 0.0

--- a/src/polymarket_insider_tracker/profiler/analyzer.py
+++ b/src/polymarket_insider_tracker/profiler/analyzer.py
@@ -91,9 +91,9 @@ class WalletAnalyzer:
             return WalletProfile(
                 address=data["address"],
                 nonce=data["nonce"],
-                first_seen=datetime.fromisoformat(data["first_seen"])
-                if data["first_seen"]
-                else None,
+                first_seen=(
+                    datetime.fromisoformat(data["first_seen"]) if data["first_seen"] else None
+                ),
                 age_hours=data["age_hours"],
                 is_fresh=data["is_fresh"],
                 total_tx_count=data["total_tx_count"],

--- a/tests/alerter/test_formatter.py
+++ b/tests/alerter/test_formatter.py
@@ -424,9 +424,9 @@ class TestTelegramMarkdown:
         result = formatter.format(high_risk_assessment)
         md = result.telegram_markdown
         for unescaped in ("0.82", "0.075", "15,000.00"):
-            assert unescaped not in md, (
-                f"unescaped {unescaped!r} would be rejected by Telegram MarkdownV2: {md!r}"
-            )
+            assert (
+                unescaped not in md
+            ), f"unescaped {unescaped!r} would be rejected by Telegram MarkdownV2: {md!r}"
         for escaped in ("0\\.82", "0\\.075", "15,000\\.00"):
             assert escaped in md, f"missing escaped {escaped!r} in {md!r}"
 

--- a/tests/tooling/test_verify.py
+++ b/tests/tooling/test_verify.py
@@ -75,6 +75,18 @@ def test_mypy_gate_uses_the_minimum_supported_dependency_resolution() -> None:
     )
 
 
+def test_format_gate_uses_black_against_the_entire_repository() -> None:
+    module = _load_module()
+
+    assert module.GATES["format"].command == (
+        module.sys.executable,
+        "-m",
+        "black",
+        "--check",
+        ".",
+    )
+
+
 def test_gate_definitions_expose_prerequisites_and_redaction_policy() -> None:
     module = _load_module()
 
@@ -293,7 +305,7 @@ def test_help_lists_every_direct_gate_command() -> None:
 
     assert result.returncode == 0
     for command in (
-        "uv run ruff format --check src tests scripts",
+        "uv run black --check .",
         "uv run ruff check src tests scripts",
         "uv run --isolated --locked --all-extras --python 3.11 mypy",
         "uv run pytest",

--- a/uv.lock
+++ b/uv.lock
@@ -207,6 +207,38 @@ wheels = [
 ]
 
 [[package]]
+name = "black"
+version = "26.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/96/3c3e09f09f44a37aac36b178a279cd19aa7001bd796187a7b162a294c81f/black-26.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96ae2c733b2aabdd9986e2c5df628ff3473676cd1c5faded1ff496cf6d74083c", size = 1970639, upload-time = "2026-05-18T17:05:11.461Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ea/5ad117b9ee3ecd933c712bcbae610006e5b7cc9f41c526cd7ed3b6c4124c/black-26.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0e48b87e03bf109288e55cfceadcfa15ff5470aca2851a851950ed2926f450d7", size = 1792130, upload-time = "2026-05-18T17:05:12.983Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3a/7c448bc623fcdfa96672531beb5a616ea5e64f6975955254d7731ffb0ad9/black-26.5.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5119fa92ae61f786e8c3662fd60aece1d0a2dd5cca5d0c79417a95e7a4272a59", size = 1846134, upload-time = "2026-05-18T17:05:14.506Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5b/0b39b3a5917f0657ac014ad2edb58c139553a478adfe7f817abf1622ff6e/black-26.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:30d3c14661f2792e9142cce3eeeb1cbc175b3eb5f733be0c8eeb99651e52b0c3", size = 1478883, upload-time = "2026-05-18T17:05:16.542Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/48/dc222692e0f95030db1bbfb6c857e76858bad09058221ea7aae815255327/black-26.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:1ef92b76f7733f282fd096ea406200b5a286c42947412b0eaff3a74e3616cefe", size = 1277776, upload-time = "2026-05-18T17:05:18.029Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/7744b906703228264ef73bdd534df88ec1ef3de45c4e78f6d31b9e32d0c9/black-26.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4ad6fa01f941920f54f2bbb35f3df7673428a0ef98a0b0840c2eaef3b110efa8", size = 2012518, upload-time = "2026-05-18T17:05:20.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c0/c5a3b1636dfd09c42534f2b3cf33506814f6d3e066fb0879ffa16c1ae860/black-26.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3915f256e75a2d7cf88d8953d37f780455dc586cc72dee059c528fe77f581217", size = 1816016, upload-time = "2026-05-18T17:05:21.84Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/0e/36044316b65ca471d3bb6d3703fd06fb50c6b727c3562f6a5a3153634f88/black-26.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d98d4137277c75dfb898ec8d846c4fd68ba1e9cf77f95e2865c203dc18f4c3d", size = 1884150, upload-time = "2026-05-18T17:05:23.546Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/33/dafc5808c2af43672912111d7c3354af1615f7e2be3bed7a878461abbe4d/black-26.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:a1dca32d9f1784af512a13410ec204c6f7f0aa9797a111c42e1c03449821c264", size = 1486825, upload-time = "2026-05-18T17:05:25.004Z" },
+    { url = "https://files.pythonhosted.org/packages/82/14/b965ee6ad2a311f28bdbf692def3ee9848d2ae289dab28b27657fcee3e78/black-26.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1037d5ac7b7b310b2632ad867ec8d0e4c4819dcdb0b820f63135da746a24e418", size = 1288646, upload-time = "2026-05-18T17:05:26.477Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5c/c384363980e11e25ca6b93205949bb331fbf35f4e0dbec376dfa6326cec8/black-26.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b36cf2ddf5566e205f6535f782a62194a184d33e175b64ae8c40b1737522be3", size = 2009020, upload-time = "2026-05-18T17:05:28.132Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/df/9f31c5e0babbfed77d505fc5d120beb98b21b33feaeded3924ea941fe360/black-26.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0", size = 1813335, upload-time = "2026-05-18T17:05:31.266Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/24/8e7b9a2fa61b0afd82209efe937557d180a1fa055bd7f6161eb9defc3719/black-26.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecb3e624844c798144e9bd986954e0adc81d8911a1f30f375e1252fe26e8c294", size = 1881614, upload-time = "2026-05-18T17:05:32.718Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ad/b4e0d9365ba8ac34f6bbab62a4b1b2dd5d618fac3fa1b8db968c844201b5/black-26.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:e1a26503279b6b310669fb0b219c39e4820b77e8189fe80f522bb511f247db0a", size = 1488925, upload-time = "2026-05-18T17:05:34.259Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4b/652b859bf5df88a751c30451b09338f7fd26a77d1271c666992f836b7711/black-26.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c34b25da232ead53a6f335b76dbea124f4d152ad568b9080d6f944bc2b34b52", size = 1289883, upload-time = "2026-05-18T17:05:36.019Z" },
+    { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -329,6 +361,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/72/3b/8314ca493654bd035cc0a66308cec9a1089cf3bc33c2837e3e265345f3cc/ckzg-2.1.5-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e15faa1145b2408e17e3b2f0b159de325b0198615aa30268bb6cd8f4385ed745", size = 102844, upload-time = "2025-09-30T19:08:52.621Z" },
     { url = "https://files.pythonhosted.org/packages/f4/9b/1729ee420865a71e68f18880341b37ef980c2881674dc0b06460253ef25e/ckzg-2.1.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46d009dba9838630183610008a81bd80aafb389d45d8293d7a2fff7a5ea82266", size = 111739, upload-time = "2025-09-30T19:08:53.54Z" },
     { url = "https://files.pythonhosted.org/packages/40/40/f259e2bf986d39717427bc12baa8189cd43f9675e81cd3bcab639e593614/ckzg-2.1.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:df66d2be54d91f74aded4ceb71e7b1f789e2636a3015f438904a22ec9de750f1", size = 101018, upload-time = "2025-09-30T19:08:54.391Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
 ]
 
 [[package]]
@@ -1219,11 +1260,11 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "0.12.1"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -1284,6 +1325,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "aiosqlite" },
+    { name = "black" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -1297,6 +1339,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "aiosqlite", marker = "extra == 'dev'", specifier = ">=0.19.0" },
     { name = "alembic", specifier = ">=1.13.0" },
+    { name = "black", marker = "extra == 'dev'", specifier = "==26.5.1" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7.0" },
     { name = "numpy", specifier = ">=1.24.0" },
@@ -1704,6 +1747,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload-time = "2026-01-30T01:02:57.882Z" },
+    { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565, upload-time = "2026-01-30T01:02:59.912Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824, upload-time = "2026-01-30T01:03:01.471Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/54/3e04f9d92a4be4fc6c80016bc396b923d2a6933ae94b5f557c939c460ee0/pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16", size = 264075, upload-time = "2026-01-30T01:03:04.143Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1b/44b0326cb5470a4375f37988aea5d61b5cc52407143303015ebee94abfd6/pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6", size = 103323, upload-time = "2026-01-30T01:03:05.412Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
+    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Contract

This is the Black-only quality-ratchet slice, based exactly on `db54f49c8b6608675234b9938ca0c3e726b141e8`.

## Changes

- Pin Black `26.5.1` in the development extra and resolve it in `uv.lock`.
- Configure Black for the repository's established 100-column, Python 3.11 syntax contract.
- Replace the static profile's Ruff formatter command with fail-closed `black --check .`, covering all 83 tracked Python files from the repository root.
- Retain Ruff for lint/import rules and replace the contradictory `ruff-format` pre-commit hook with the matching pinned Black hook.
- Apply Black to all four files that violated the configured repository contract; the rewrites are AST-identical to the base.
- Add a focused verifier contract test and update active operator/Spec Kit documentation.

No pytype, Vulture, Complexipy, bespoke prose/config parser, or committed `.claude/skills` is included.

## Verification

- `uv run python scripts/verify.py --profile static` — passed: lock, Black (83 files), Ruff, strict mypy (41 files).
- Python 3.11, 3.12, and 3.13 compatibility profiles — each passed with 766 tests passed and 2 platform skips.
- `uv run --env-file .env.example python scripts/verify.py --profile all --json` — all eight gates passed, including real PostgreSQL/Redis probes and the disposable migration cycle.
- `uv run pytest tests/tooling/test_verify.py -q` — 28 passed.
- `uv run pre-commit run black --all-files` and `uv run pre-commit run ruff --all-files` — passed without modifications.
- `actionlint .github/workflows/ci.yml` and `git diff --check` — passed.

## Independent review chain

- Agy / `gemini-3.8-flash-high` reviewed the first candidate and returned `NEEDS_CHANGES` for the retained `ruff-format` pre-commit hook. The finding was reproduced and fixed.
- Claude Code / `fable` reviewed exact final candidate `422a6f3b843ce58d62fbf5955c3b3da66786db87` and returned `SHIP` with no findings.
- Codex independently read the complete final diff, verified AST equivalence for all formatter rewrites, and reran the real gates on the exact head.

This PR is intentionally not configured for auto-merge; merge requires explicit approval.
