### PR TITLE
docs: codify repository agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,135 @@
+# Repository Agent Guidance
+
+Read the [constitution](.specify/memory/constitution.md), the [slice index](specs/README.md),
+and the active slice's spec, plan, tasks, contracts, and owned
+[gap-register entries](specs/audit/gap-register.md) before changing the repository.
+The constitution governs; specs own what/why; plans own implementation. This file
+is an entry point to those authorities, not a replacement for them.
+
+## Scope and safe effects
+
+- This is read-only research and monitoring, not trading execution or advice.
+  Detection signals are evidence for investigation, not proof of wrongdoing.
+- Preserve public APIs, CLI/configuration, schemas, thresholds, and behavior unless
+  an approved specification explicitly authorizes a change and migration path.
+- Tests and verification must not accidentally contact market, chain, or notification
+  services. Real Discord/Telegram delivery requires explicit authorization. Dry runs
+  must neither deliver nor poison later real-delivery deduplication state.
+- Preserve durable research assessments. Persistence failures must be observable
+  without blocking an otherwise authorized alert attempt.
+- Never log secrets or credential-bearing URLs. Exercise migration downgrades only
+  in disposable databases, never in the configured application database.
+
+## Spec Kit and change ownership
+
+Follow the applicable sequence: specify → clarify → plan → reviewer-owned domain
+requirements-quality checklists → tasks → analyze → human validation → implement
+→ converge. Record existing approval honestly; new scope needs its own validation.
+
+Explicitly activate the intended feature before every per-slice command. For
+slice 002, from the repository root (choose the actual slice, not this example blindly):
+
+```bash
+SPECIFY_FEATURE_DIRECTORY=specs/002-reproducible-runtime .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks
+```
+
+Do not let ignored local pointer state silently choose a slice. The built-in
+`checklists/requirements.md` is author-owned; domain requirements-quality checklists
+are human-reviewer-owned. Agents must not mark human criteria satisfied.
+
+Update owned tasks and gaps with actual evidence. Append corrections and verification
+receipts rather than rewriting historical results to imply earlier success. Keep
+unrelated concerns in separate PRs; each requested quality gate and its underlying
+remediation belong together. Preserve user changes and use one writer per worktree.
+
+## Navigation and maintainable code
+
+Use CodeGraph before broad source searches when available: check status, initialize
+or sync as needed, explore relevant symbols/callers/tests, and inspect affected code
+after changes. Keep `.codegraph/` in local Git `info/exclude`, not tracked state.
+If unavailable, state that briefly and use `rg`.
+
+Prefer cohesive small functions, explicit typed boundaries, early returns, and
+named domain operations. Use tables or polymorphism when they clarify real variants;
+do not trade readable branches for indirection just to lower an analyzer score.
+Preserve evaluation order, transactions, retries, cancellation, and error behavior.
+Start behavior changes with failing regression evidence when practical; otherwise
+record why and the equivalent reproducible check in the plan.
+
+Use established libraries before rebuilding protocols. Do not reintroduce copied
+tool-specific skill trees such as `.claude/skills`. Preserve the managed
+`.agents/skills/speckit-*` integration; shared project guidance belongs here and in
+owned specs, not duplicated global instruction payloads.
+
+## Test doubles and behavioral coverage
+
+Prefer real value objects and lightweight working fakes. Reusable fakes need shared
+contract tests against real implementations for exercised behavior. Keep real local
+database and transport tests where they provide stronger evidence.
+
+Do not introduce new `unittest.mock` doubles or patches (`Mock`, `MagicMock`,
+`AsyncMock`, or `patch`). Migrate existing uses through the owned fakes work item;
+do not expand an unrelated PR into a repository-wide test rewrite.
+
+Do not replace mocks with a homemade mock framework: no dynamic attribute trees,
+generic return-value/side-effect DSL, or call-assertion framework. Assert resulting
+state, payloads, returned results, and failures. Delivery/retry counts are appropriate
+when the interaction itself is the external contract. `pytest.monkeypatch` remains
+appropriate for environment isolation and narrow boundary/failure injection. A
+functional HTTP transport remains a fake despite an upstream “Mock” name.
+
+Preserve applicable ingest → enrich → detect/score → persist → deliver/suppress
+coverage, including failure, retry, deduplication, restart, and degraded dependencies.
+Test counts and line coverage alone are not completion evidence. Redis fakes do not
+replace real Redis parity, and SQLite does not establish PostgreSQL driver/migration
+correctness. These are acceptance requirements, not claims that every existing test
+already meets them; consult the active slice's tasks and evidence.
+
+## Required verification
+
+Use the checked-in lock and supported Python 3.11–3.13. Black is the formatter
+(100 columns); Ruff owns lint/import rules. The independent strict type gates are
+mypy (`src`, `scripts`) and Pyright (`src/polymarket_insider_tracker`). Preserve
+their configured scope and strictness; do not substitute another checker silently.
+
+```bash
+uv sync --locked --all-extras --python 3.13
+uv run python scripts/verify.py --profile static
+uv run python scripts/verify.py --profile compatibility
+uv run --env-file .env python scripts/verify.py --profile services
+```
+
+Follow the [quickstart](specs/002-reproducible-runtime/quickstart.md) for local
+service setup and clean-checkout verification, including isolated compatibility
+runs for each supported minor. `uv run python scripts/verify.py --help` lists the
+actual underlying gate commands. The [runtime contract](specs/002-reproducible-runtime/contracts/runtime-verification.md)
+owns exact membership, exits, and service/migration safety.
+
+Vulture runs at default confidence over `src tests scripts alembic conftest.py`.
+Complexipy checks functions **and module-level control flow** over that scope with
+maximum cognitive complexity **5**, using the fail-closed launcher:
+
+```bash
+uv run --isolated --locked --all-extras --python 3.11 python scripts/complexipy_gate.py src tests scripts alembic conftest.py --max-complexity-allowed 5 --no-ignore --ignore-complexity=false --snapshot-ignore=true --snapshot-create=false --exclude=. --check-script=true
+```
+
+Fix underlying issues. Do not introduce baselines, grandfathering, allowlists,
+exclusions, suppressions, reduced confidence, raised thresholds, non-blocking status,
+or weaker types to make checks green. Do not replace full-tree enforcement with
+diff/staged checks or use snapshots, report-only success, or cwd configuration to
+evade the launcher. Low scores do not by themselves prove low cognitive load.
+
+## Review and delivery
+
+When the requested multi-tool workflow is used, the sequence is Agy first pass →
+Claude Code Fable correction → independent Codex adversarial review. This is not a
+mandate to run three agents for every change. Preserve immutable first-pass and
+corrective commits. Record unavailable tools/models honestly. Inspect
+the actual diff and independently rerun verification before accepting a worker's
+report; a launch, idle signal, test count, or green summary is not proof.
+
+Prepare a PR only after required checks and convergence pass. Verify remote required
+checks at the exact head; do not bypass branch protection. Patrick's approval is
+required to merge. After an approved merge, verify the resulting commit/tree and
+main CI before reporting completion. Distinguish implemented, locally verified,
+PR-green, approved, merged, and main-verified states in handoffs.

--- a/specs/002-reproducible-runtime/checklists/agent-guidance.md
+++ b/specs/002-reproducible-runtime/checklists/agent-guidance.md
@@ -1,0 +1,9 @@
+# Agent Guidance Requirements-quality Review
+
+Reviewer-owned: only Patrick or his designated human reviewer may mark these items satisfied.
+These are requirements-quality criteria, not agent-reported test results.
+
+- [ ] The root guidance accurately codifies approved practices without changing governance.
+- [ ] Safety, compatibility, and approval boundaries are explicit and unambiguous.
+- [ ] Test-double policy is distinguished from completed repository-wide remediation.
+- [ ] The guidance remains concise and delegates detailed authority to the constitution and specs.

--- a/specs/002-reproducible-runtime/contracts/agent-guidance.md
+++ b/specs/002-reproducible-runtime/contracts/agent-guidance.md
@@ -1,0 +1,28 @@
+# Root Agent Guidance Contract
+
+This documentation-only follow-up implements Patrick's request for a separate root `AGENTS.md`
+codifying the practices established during slice 002. It changes no public runtime contract.
+
+## Requirements and Sources
+
+| Guidance | Authoritative basis | Acceptance evidence |
+|---|---|---|
+| Read-only monitoring, safe alerts, durable records, compatibility | [Constitution](../../../.specify/memory/constitution.md), principles I–V | Root guidance links and accurately summarizes the boundaries |
+| Explicit slice activation, artifact/checklist ownership, truthful evidence, approval before merge | Constitution, Development Workflow and Quality Gates | Root guidance gives a valid explicit activation command and does not authorize agent self-signoff |
+| Locked setup, Black/Ruff, strict mypy/Pyright, Vulture, Complexipy <=5, real services and supported minors | [Runtime contract](runtime-verification.md), `pyproject.toml`, `scripts/verify.py`, CI | Commands agree with tracked executable configuration; no new checker or exception |
+| Low cognitive load, underlying remediation, separate coherent PRs, no `.claude/skills` | Patrick's explicit quality and repository-hygiene instructions | Root guidance rejects metric gaming and copied tool-specific skill trees without deleting the managed Spec Kit integration |
+| Working fakes, observable outcomes, independent verification of delegated work | Patrick's test-double and Agy/Claude/Codex review instructions; constitution principle III | Policy is stated without claiming all legacy mocks are already removed or all fakes are already contract-tested |
+| CodeGraph before broad code exploration | Patrick's supplied AGENTS instructions | Local generated index handling and unavailable-tool fallback are explicit |
+
+## Non-goals
+
+- No constitution amendment, model mandate for every future task, new approval gate, or new feature.
+- No test-double implementation, source-code refactor, dependency change, or CI modification.
+- No enforcement script that parses prose as a second configuration authority.
+- No duplication of global skills or replacement of the installed Spec Kit integration.
+
+## Verification
+
+Check relative links, resolve the explicit feature example using the real prerequisite script,
+compare commands with the real verifier, and run existing static/compatibility profiles. Record
+evidence in `evidence/agent-guidance.md`. Preserve human ownership of domain checklist decisions.

--- a/specs/002-reproducible-runtime/evidence/agent-guidance.md
+++ b/specs/002-reproducible-runtime/evidence/agent-guidance.md
@@ -1,0 +1,46 @@
+# Root Agent Guidance Evidence
+
+## Local preparation — 2026-09-09 UTC
+
+Base: `7a4f11cd645dd21b049db3649747bb4e03b652e2` (merged PR116).
+Branch: `docs/root-agent-guidance`. Scope: root guidance and its owned documentation;
+no application, test, script, dependency, workflow, or constitution modification.
+
+Codex read the constitution, runtime spec/plan/contract, actual `pyproject.toml`,
+CI workflow, and verifier commands before authoring. Specification/plan additions
+preceded the root file. The root guidance explicitly distinguishes desired test
+policy from the pending separate mocks-to-fakes migration.
+
+Executed on Apple Silicon macOS, Python 3.13.14:
+
+- `uv sync --locked --all-extras --python 3.13`: passed, 102 resolved packages.
+- `uv run python scripts/verify.py --profile static`: all seven gates passed,
+  including Black, Ruff, isolated Python 3.11 mypy/Pyright/Vulture/Complexipy.
+  mypy checked 42 source files; Pyright reported zero errors/warnings; full-scope
+  Complexipy accepted every function and module at the unchanged maximum of 5.
+- `uv run python scripts/verify.py --profile compatibility`: passed lock/imports
+  and the complete suite, **860 passed, 2 existing skips, 16 warnings**, in 14.80s
+  pytest time. The legacy unawaited AsyncMock warning remains a separate fakes
+  concern; no warning-free claim is made.
+- Explicit `SPECIFY_FEATURE_DIRECTORY=specs/002-reproducible-runtime` with the
+  real `check-prerequisites.sh --json --require-tasks --include-tasks`: passed,
+  returning the intended feature directory and tasks.
+- Seven local Markdown links in the root file and guidance contract resolved to
+  existing files. `scripts/verify.py --help` matched the documented underlying
+  gate commands. `git diff --check` passed.
+
+An independent read-only Codex documentation reviewer checked policy completeness,
+source consistency, links, commands, ownership, and completion claims. It returned
+REVISE for two omissions: the conditional Agy → Fable → Codex sequence and the ban
+on introducing new unittest.mock doubles. Both were corrected while preserving
+valid monkeypatch/functional-transport use and separate-PR scope. The reviewer
+re-read the corrections and evidence, then returned SHIP for locally prepared
+documentation with no further actionable findings. It explicitly did not claim
+PR readiness or independently rerun the parent's recorded tests.
+
+## Not yet established
+
+The guidance branch has not been reconciled with the final fakes follow-up, published
+as a PR, approved, or merged. No new service/migration run or full Linux matrix is
+claimed by this local documentation checkpoint. Existing runtime/service contracts
+are unchanged. Human-owned requirements-quality checklist items remain unchecked.

--- a/specs/002-reproducible-runtime/plan.md
+++ b/specs/002-reproducible-runtime/plan.md
@@ -223,3 +223,21 @@ monitoring E2E proof preserves slice ownership.
 ## Complexity Tracking
 
 No constitution violation requires justification.
+
+## Root Agent Guidance Follow-up Plan
+
+This documentation-only follow-up is a separate PR from the mocks-to-fakes implementation.
+
+1. Record the requested guidance contract and trace it to the constitution, current runtime gates,
+   and Patrick's explicit quality/test-double instructions. No new governance is introduced.
+2. Add a concise root `AGENTS.md` with relative links, an explicitly activated slice example, the
+   canonical verifier commands, and the exact fail-closed Complexipy command. Preserve the managed
+   `.agents/skills/speckit-*` integration; do not recreate `.claude/skills` or copy global skills.
+3. Check all local links and command examples against actual tracked scripts/configuration. Review
+   for misleading statements about type-checker scope, advisory CI, fake coverage, or completed work.
+4. Run the existing static and compatibility profiles. No runtime change is intended; preserve the
+   service and migration contracts unchanged. Record exact evidence and limitations separately.
+5. Reconcile with the completed fakes PR before publishing this subsequent PR. Keep human-owned
+   reviewer criteria unchecked and obtain Patrick's approval before merging.
+
+No new dependencies, scripts, application behavior, CI gates, or schema changes are needed.

--- a/specs/002-reproducible-runtime/spec.md
+++ b/specs/002-reproducible-runtime/spec.md
@@ -204,3 +204,16 @@ and automated checks; verify that they name one consistent support matrix and re
   quality gates; those checks belong to bounded live-safe verification or explicitly authorized release work.
 - This slice executes first even though its numeric feature prefix is `002`, because every later slice
   depends on a reproducible database, dependency set, and blocking local/CI gates.
+
+## Agent Guidance Follow-up
+
+Patrick requested a separate root `AGENTS.md` PR to codify the approved development practices.
+The root file MUST provide a concise, tool-neutral entry point to the constitution, active slice,
+verification commands, safe-effects rules, test-double policy, complexity budget, and review/merge
+gates. It MUST distinguish existing executable enforcement from behavioral requirements and pending
+work. It MUST NOT amend the constitution, expand product scope, duplicate installed skill payloads,
+or claim the separate mocks-to-fakes migration has already shipped.
+
+Acceptance: a contributor can identify the active slice, required verification, prohibited shortcuts,
+and human-owned approvals from the root file; each material rule traces to existing approval or an
+owned specification. See [the guidance contract](contracts/agent-guidance.md).

--- a/specs/002-reproducible-runtime/tasks.md
+++ b/specs/002-reproducible-runtime/tasks.md
@@ -337,3 +337,15 @@ completion is not evidence for this phase; each item below is checked only when 
   preserve the scorer's base IEEE-754 addition order at the alert threshold; and close Complexipy's
   automatic-snapshot, cwd-exclusion, and omitted-module-control-flow escape hatches with real red-to-green
   regression tests, aligned contracts, and appended evidence.
+
+## Root Agent Guidance Follow-up (Separate PR)
+
+The AG prefix isolates this documentation ledger from the concurrently prepared fakes ledger.
+
+- [X] AG001 Record the root-guidance contract and implementation plan before authoring the root file.
+- [X] AG002 Add root `AGENTS.md`, grounded in approved policy and executable repository configuration.
+- [X] AG003 Verify relative links and command examples; review policy/implementation distinctions.
+- [X] AG004 Run existing static and compatibility profiles; results are in `evidence/agent-guidance.md`.
+- [ ] AG005 Reconcile against the final fakes follow-up and independently review the guidance diff.
+- [ ] AG006 Open the separate PR and verify required checks at its exact head.
+- [ ] AG007 Obtain Patrick's merge approval, merge, and verify resulting main CI.

--- a/specs/audit/gap-register.md
+++ b/specs/audit/gap-register.md
@@ -126,6 +126,16 @@ pointer MUST NOT be trusted across slices or clones.
   environment coverage, not absence of tests.
 - Trading execution, UI work, monetization, and accusations of actual insider conduct remain outside scope.
 
+## Agent Guidance Follow-up
+
+**AG-G001 — root contributor/agent guidance**: Patrick requested a separate root `AGENTS.md` to
+codify the approved Spec Kit, safety, quality, test-double, and review practices. Owner: Codex;
+scope: slice 002 documentation only. Status: implemented, locally verified, and independently
+reviewed; final fakes reconciliation, publication, and merge remain pending. Acceptance and source mapping are in
+[the guidance contract](../002-reproducible-runtime/contracts/agent-guidance.md); completion evidence
+belongs in `specs/002-reproducible-runtime/evidence/agent-guidance.md`. The mocks-to-fakes migration
+remains a separate work item and is not closed by this document.
+
 ## Audit Limitations
 
 - Provider behavior was checked with short, read-only probes on 2026-09-06; no availability promise


### PR DESCRIPTION
## Summary

Add a concise, tool-neutral root AGENTS.md that codifies the practices approved during
slice002: explicit Spec Kit activation and ownership, safe effects, behavioral fakes,
locked verification, strict type/dead-code/complexity gates, honest evidence, independent
review, and approval before merge. Link to the authoritative specs rather than copying
global skill payloads or adding another configuration authority.

The guidance reflects merged PR117's no-mocks contract and calls out unresolved G-018
instead of claiming dry-run dedup isolation is already implemented. Preserve the managed
Spec Kit integration and human-owned checklist markers. This changes only eight
documentation files; stale docs-directory pruning is a separate PR.

## Verification

- All12 local verifier gates passed on Python3.13, including PostgreSQL15/Redis7 and
  disposable migration lifecycle; isolated Python3.11/3.12 compatibility also passed.
- All nine local links resolve, explicit slice activation returns the intended feature,
  and the reconciled diff contains no runtime, test, dependency or workflow changes.
- Independent read-only documentation review returned SHIP.
- Original guidance checkpoint1909680 is preserved; main357c350 was integrated by
  retaining both task ledgers. PR117 merge/main verification is recorded truthfully.

See specs/002-reproducible-runtime/contracts/agent-guidance.md and
specs/002-reproducible-runtime/evidence/agent-guidance.md. Merge requires Patrick's approval.
