### PR TITLE
docs(agents): reconcile G-018 status with slice-003 closure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,14 @@ is an entry point to those authorities, not a replacement for them.
 - Tests and verification must not accidentally contact market, chain, or notification
   services. Real Discord/Telegram delivery requires explicit authorization. Dry runs
   must neither deliver nor poison later real-delivery deduplication state.
-  The existing dedup-ordering gap is tracked as G-018 in slice 003; do not claim it
-  is fixed or use dry-run alone as evidence that shared delivery state is isolated.
+  The dry-run dedup-ordering gap G-018 is closed by slice 003 (see
+  `specs/audit/gap-register.md`): FR-009 dry-run safety holds because
+  `AlertDispatcher.dispatch` returns before any delivery-state write, proven by the
+  channel-scoped tests (`tests/alerter/test_deduplication.py`,
+  `tests/integration/test_end_to_end.py`) and retained in
+  `specs/003-safe-observable-operation/evidence/verification.md`. Do not treat a dry
+  run alone as evidence that shared delivery state is isolated — cite the gap-register
+  entry and the channel-scoped tests.
 - Preserve durable research assessments. Persistence failures must be observable
   without blocking an otherwise authorized alert attempt.
 - Never log secrets or credential-bearing URLs. Exercise migration downgrades only


### PR DESCRIPTION
The root agent guidance still described G-018 as open after slice 003 closed it. This updates the paragraph to match the gap register, names the dispatcher dry-run guard, and cites the retained channel-scoped tests and verification record. The caution against treating a dry run alone as shared-state isolation evidence remains.

Only AGENTS.md changes. Independent review accepted commit 95215b4b8ee832690a578ce853df400dee06ef80 (tree 6c5ff06c5b76fa8aa80edd4b0c637b5f22e3e61a): inspected guard and test assertions, verified all cited paths, and checked the base/head diff. Retained local verification: 64 targeted tests and seven static gates; no fresh local full-suite claim. Hosted required CI must pass before merge.
